### PR TITLE
fix: optional css and js arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,10 +30,10 @@ export async function addToTab(tab, contentScripts) {
 			for (const group of contentScripts) {
 				const allFrames = group.all_frames;
 				const runAt = group.run_at;
-				for (const file of group.css) {
+				for (const file of group.css || []) {
 					injections.push(p(chrome.tabs.insertCSS, tabId, {file, allFrames, runAt}));
 				}
-				for (const file of group.js) {
+				for (const file of group.js || []) {
 					injections.push(p(chrome.tabs.executeScript, tabId, {file, allFrames, runAt}));
 				}
 			}


### PR DESCRIPTION
Makes `css` and `js` arrays optional.

Otherwise, with this config:

```
  "content_scripts": [
    {
      "matches": ["https://github.com/*"],
      "js": ["content.js"]
    }
  ]
```

We get this error (which is silenced):

```
TypeError: group.css is not iterable
    at addToTab
```
