### PR TITLE
fix(safari): prevent context loss by calling scripting methods natively

### DIFF
--- a/source/register-content-script-shim.test.ts
+++ b/source/register-content-script-shim.test.ts
@@ -1,0 +1,29 @@
+import {
+	describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+describe('registerContentScript context binding', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('should call chrome.scripting.registerContentScripts with the correct `this` context', async () => {
+		const mockRegister = vi.fn();
+
+		// Setup the global mock before importing the shim
+		// @ts-expect-error Mocking global objects
+		globalThis.chrome = {
+			scripting: {
+				registerContentScripts: mockRegister,
+				unregisterContentScripts: vi.fn(),
+			},
+		};
+
+		const {registerContentScript} = await import('./register-content-script-shim.js');
+
+		await registerContentScript({matches: ['*://*.example.com/*'], js: ['script.js']});
+
+		expect(mockRegister).toHaveBeenCalled();
+		expect(mockRegister.mock.instances[0]).toBe(globalThis.chrome.scripting);
+	});
+});

--- a/source/register-content-script-shim.ts
+++ b/source/register-content-script-shim.ts
@@ -1,15 +1,15 @@
 import registerContentScriptPonyfill from 'content-scripts-register-polyfill/ponyfill.js';
 
-export const chromeRegister = globalThis.chrome?.scripting?.registerContentScripts;
-export const firefoxRegister = globalThis.browser?.contentScripts?.register;
+export const hasChromeRegister = Boolean(globalThis.chrome?.scripting?.registerContentScripts);
+export const hasFirefoxRegister = Boolean(globalThis.browser?.contentScripts?.register);
 
 export async function registerContentScript(
 	contentScript: Omit<chrome.scripting.RegisteredContentScript, 'id' | 'world'> & {matches: string[]},
 ): Promise<browser.contentScripts.RegisteredContentScript> {
-	if (chromeRegister) {
+	if (hasChromeRegister) {
 		const id = 'webext-dynamic-content-script-' + JSON.stringify(contentScript);
 		try {
-			await chromeRegister([{
+			await globalThis.chrome.scripting.registerContentScripts([{
 				...contentScript,
 				id,
 			}]);
@@ -30,8 +30,8 @@ export async function registerContentScript(
 		css: contentScript.css?.map(file => ({file})),
 	} as const;
 
-	if (firefoxRegister) {
-		return firefoxRegister(firefoxContentScript);
+	if (hasFirefoxRegister) {
+		return globalThis.browser.contentScripts.register(firefoxContentScript);
 	}
 
 	return registerContentScriptPonyfill(firefoxContentScript);


### PR DESCRIPTION
Uses `globalThis.chrome.scripting.registerContentScripts` and `globalThis.browser.contentScripts.register` directly instead of cached references to prevent `this` context loss in Safari.

Unblocks https://github.com/refined-github/refined-github/pull/9441 by re-enabling dynamic content script registration on Safari, which was previously broken because the cached `chrome.scripting` reference lost its `this` binding.