### PR TITLE
Restore Safari support

### DIFF
--- a/source/register-content-script-shim.ts
+++ b/source/register-content-script-shim.ts
@@ -1,13 +1,15 @@
 import registerContentScriptPonyfill from 'content-scripts-register-polyfill/ponyfill.js';
 
+export const chromeRegister = globalThis.chrome?.scripting?.registerContentScripts;
+export const firefoxRegister = globalThis.browser?.contentScripts?.register;
 
 export async function registerContentScript(
 	contentScript: Omit<chrome.scripting.RegisteredContentScript, 'id' | 'world'> & {matches: string[]},
 ): Promise<browser.contentScripts.RegisteredContentScript> {
-	if (globalThis.chrome?.scripting?.registerContentScripts) {
+	if (chromeRegister) {
 		const id = 'webext-dynamic-content-script-' + JSON.stringify(contentScript);
 		try {
-			await chrome.scripting.registerContentScripts([{
+			await chromeRegister([{
 				...contentScript,
 				id,
 			}]);
@@ -28,8 +30,8 @@ export async function registerContentScript(
 		css: contentScript.css?.map(file => ({file})),
 	} as const;
 
-	if (globalThis.browser?.contentScripts?.register) {
-		return browser.contentScripts.register(firefoxContentScript);
+	if (firefoxRegister) {
+		return firefoxRegister(firefoxContentScript);
 	}
 
 	return registerContentScriptPonyfill(firefoxContentScript);

--- a/source/register-content-script-shim.ts
+++ b/source/register-content-script-shim.ts
@@ -9,7 +9,8 @@ export async function registerContentScript(
 	if (chromeRegister) {
 		const id = 'webext-dynamic-content-script-' + JSON.stringify(contentScript);
 		try {
-			await chromeRegister([{
+			// Don't use `chromeRegister` directly https://github.com/fregante/webext-dynamic-content-scripts/pull/80
+			await chrome.scripting.registerContentScripts([{
 				...contentScript,
 				id,
 			}]);

--- a/source/register-content-script-shim.ts
+++ b/source/register-content-script-shim.ts
@@ -6,7 +6,7 @@ export const firefoxRegister = globalThis.browser?.contentScripts?.register;
 export async function registerContentScript(
 	contentScript: Omit<chrome.scripting.RegisteredContentScript, 'id' | 'world'> & {matches: string[]},
 ): Promise<browser.contentScripts.RegisteredContentScript> {
-	if (chromeRegister) {
+	if (chromeRegister !== undefined) {
 		const id = 'webext-dynamic-content-script-' + JSON.stringify(contentScript);
 		try {
 			// Don't use `chromeRegister` directly https://github.com/fregante/webext-dynamic-content-scripts/pull/80

--- a/source/register-content-script-shim.ts
+++ b/source/register-content-script-shim.ts
@@ -1,15 +1,13 @@
 import registerContentScriptPonyfill from 'content-scripts-register-polyfill/ponyfill.js';
 
-export const chromeRegister = globalThis.chrome?.scripting?.registerContentScripts;
-export const firefoxRegister = globalThis.browser?.contentScripts?.register;
 
 export async function registerContentScript(
 	contentScript: Omit<chrome.scripting.RegisteredContentScript, 'id' | 'world'> & {matches: string[]},
 ): Promise<browser.contentScripts.RegisteredContentScript> {
-	if (chromeRegister) {
+	if (globalThis.chrome?.scripting?.registerContentScripts) {
 		const id = 'webext-dynamic-content-script-' + JSON.stringify(contentScript);
 		try {
-			await chromeRegister([{
+			await chrome.scripting.registerContentScripts([{
 				...contentScript,
 				id,
 			}]);
@@ -30,8 +28,8 @@ export async function registerContentScript(
 		css: contentScript.css?.map(file => ({file})),
 	} as const;
 
-	if (firefoxRegister) {
-		return firefoxRegister(firefoxContentScript);
+	if (globalThis.browser?.contentScripts?.register) {
+		return browser.contentScripts.register(firefoxContentScript);
 	}
 
 	return registerContentScriptPonyfill(firefoxContentScript);


### PR DESCRIPTION
Even if the browser is still affected by https://github.com/refined-github/refined-github/issues/8405, it's still up to the developer to decide whether to implement it.

At this point, Safari 27.0 was silently failing to register any scripts.

Interestingly, this was already reported in https://github.com/fregante/webext-dynamic-content-scripts/pull/79